### PR TITLE
CRITICAL: Revert the removal of Z suffix on text fields

### DIFF
--- a/libsql.go
+++ b/libsql.go
@@ -747,7 +747,6 @@ Outerloop:
 				return libsqlError(fmt.Sprint("failed to get string for column ", i), statusCode, errMsg)
 			}
 			str := C.GoString(ptr)
-			str = strings.TrimSuffix(str, "Z")
 			C.libsql_free_string(ptr)
 			for _, format := range []string{
 				"2006-01-02 15:04:05.999999999-07:00",


### PR DESCRIPTION
This was introduced by https://github.com/tursodatabase/go-libsql/pull/44 as a way to get parity with [go-sqlite3](https://github.com/mattn/go-sqlite3) but it doesn't do that. What is does is a trim when the declared type is TIMESTAMP, DATE, or DATETIME:

https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L2259-L2261
```go
case columnTimestamp, columnDatetime, columnDate:
	var t time.Time
	s = strings.TrimSuffix(s, "Z")
```

This results in weird behaviors, as **all text fields are returning values missing a trailing `'Z'` upon query**. This PR reverts that change.

If I may offer a piece of feedback: this is a major bug and PRs like this shouldn't be merged without proper testing (automated tests, but at least manual tests). 